### PR TITLE
updated LIF neuron parameters to reduce R, \tau

### DIFF
--- a/src/neurons/LIF.jl
+++ b/src/neurons/LIF.jl
@@ -12,8 +12,8 @@ Contains the necessary parameters for describing a Leaky Integrate-and-Fire (LIF
 - `state::T`: Current membrane potential (mV)
 """
 @with_kw struct LIF{T<:Number}<:AbstractNeuron 
-    τ::T = 8.         
-    R::T = 10.E3      
+    τ::T = 4.         
+    R::T = 6.      
     θ::T = 30.      
     I::T = 40.      
 


### PR DESCRIPTION
Old LIF parameters spiked on every time step because of a mismatch between kOhms and Ohms; R should be in kOhms so currents can be in units of mA.